### PR TITLE
Arreglo de errores en characters, estado de cabezal y se agregaron restricciones

### DIFF
--- a/cabezal.wlk
+++ b/cabezal.wlk
@@ -17,7 +17,9 @@ object cabezal {
     }
 
     method mover(direccion) {
-        position = direccion.siguiente(self.position())
+      const siguiente = direccion.siguiente(self.position()) 
+      mapa.validarSiEstaDentro(siguiente)
+      position = siguiente
     }
 
 
@@ -40,8 +42,15 @@ object cabezal {
     //por ahora solo selecciona un aliado para moverlo
     method seleccionarAliado() {
         mapa.validarSeleccionAliada(self.position())
+        self.validarSiTengoAlgoSeleccionado()
         seleccionActualAliada = self.obtenerPjAliado(self.position())
         modoCabezal = cabezalSeleccion
+    }
+
+    method validarSiTengoAlgoSeleccionado() {
+      return if (modoCabezal == cabezalSeleccion) {
+        self.error("Ya tengo seleccionada una unidad")
+      }
     }
 
     method obtenerPjAliado(_position) {
@@ -49,6 +58,8 @@ object cabezal {
     }
 
     method moverPj() {
+      mapa.validarSiHayAlgunPersonaje(self.position())
+      seleccionActualAliada.limpiarEnemigosAlAlcance()
       seleccionActualAliada.mover(self.position())
       seleccionActualAliada.definirEnemigosAlAlcance(self.position())
       seleccionActualAliada = null

--- a/characters.wlk
+++ b/characters.wlk
@@ -18,6 +18,10 @@ class Comandante {
         enemigosAlAlcance.remove(enemigo)
     }
 
+    method limpiarEnemigosAlAlcance() {
+        enemigosAlAlcance.clear()
+    }
+
     method definirEnemigosAlAlcance(posicion){
         enemigosAlAlcance.addAll(self.definirEnemigoHacia(arriba.siguiente(posicion))) 
         enemigosAlAlcance.addAll(self.definirEnemigoHacia(abajo.siguiente(posicion)))
@@ -56,6 +60,7 @@ class Comandante {
         mapa.quitarEnemigo(self)
         self.quitarEnemigoAlAlcance(self)
         game.removeVisual(self)
+        cabezal.modoCabezal(cabezalNormal)
     }
     
 

--- a/map.wlk
+++ b/map.wlk
@@ -15,6 +15,22 @@ object mapa {
     const property aliados = #{}
     const property enemigos = #{}
 
+    method validarSiEstaDentro(posicion) {
+        return if (not self.estaDentro(posicion)) {
+             cabezal.error("No me puedo mover a esa posición ya que esta fuera de los limites!")
+        }
+    }
+
+    method estaDentro(posicion) {
+		return posicion.x().between(0, game.width() - 1) and posicion.y().between(0, game.height() - 1)
+	}
+
+    method validarSiHayAlgunPersonaje(posicion) {
+        return if (self.hayAliadosEn(posicion) or self.hayEnemigosEn(posicion)) {
+            cabezal.error("No puedo mover la seleccion actual a esa posición ya que hay otro personaje")
+        }
+    }
+
     method quitarEnemigo(enemigo) {
         enemigos.remove(enemigo)
     }


### PR DESCRIPTION
- Validacion de movimiento del cabezal para que no salga del tablero
- Validacion para que no se pueda poner un objeto(personaje) sobre otro a la hora de moverlo
- Validacion que cuando tiene seleccionado un personaje no deje seleccionar a otro hasta que cancele o por alguna razon salga de la seleccion
- Correccion de error de que al mover un personaje de posicion permitia seguir batallando con los enemigos que estaban alrededor de su anterior posicion (limpia enemigosAlAlcance antes de mover)
- Correccion de que al matar un enemigo termina el turno (vuelve el cabezal a modo normal)